### PR TITLE
Improve compatibility via Parser method change

### DIFF
--- a/Source/Metadata.psm1
+++ b/Source/Metadata.psm1
@@ -654,7 +654,7 @@ function Get-Metadata {
     }
 
     $Tokens = $Null; $ParseErrors = $Null
-    $AST = [System.Management.Automation.Language.Parser]::ParseInput( $ManifestContent, $Path, [ref]$Tokens, [ref]$ParseErrors )
+    $AST = [System.Management.Automation.Language.Parser]::ParseInput( $ManifestContent, [ref]$Tokens, [ref]$ParseErrors )
 
     $KeyValue = $Ast.EndBlock.Statements
     $KeyValue = @(FindHashKeyValue $PropertyName $KeyValue)


### PR DESCRIPTION
Hi Joel!

It looks like the four parameter ParseInput method was introduced in PowerShell 5, see #6 for more info - swapped this out for the three parameter method.

Not sure if there's more to be done, but superficially seems to work.

Cheers!
