### PR TITLE
Removed `-NoNewLine` parameter from `Set-Content`

### DIFF
--- a/Source/Metadata.psm1
+++ b/Source/Metadata.psm1
@@ -592,7 +592,7 @@ function Update-Metadata {
                                            ).Insert($Extent.StartOffset, $Value)
 
     if(Test-Path $Path) {
-        Set-Content -Encoding UTF8 -Path $Path -Value $ManifestContent -NoNewline
+        Set-Content -Encoding UTF8 -Path $Path -Value $ManifestContent
     } else {
         $ManifestContent
     }


### PR DESCRIPTION
`Set-Content` only supports the `-NoNewLine` parameter starting with Windows Powershell 5
closes #15 

_not sure if you want the PR to increment the psd1 version_