### PR TITLE
Fixed lowercase of module files

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -35,6 +35,10 @@ $Script:TraceVerboseTimer.Start()
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
+if ($env:APPVEYOR_PROJECT_NAME) {
+    $ModuleName = $env:APPVEYOR_PROJECT_NAME
+}
+
 function init {
     #.Synopsis
     #   The init step always has to run.


### PR DESCRIPTION
AppVeyor  creates the folder of the project in lower case.
Buy using `Split-Path -Leaf`, this is used for the module's
psm1 and psd1 files during compilation.
By using AppVeyor's Project_Name env var, we can fix this