### PR TITLE
Add Import-ParameterConfiguration 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,7 @@
             "type": "shell",
             "command": "${workspaceFolder}\\build.ps1",
             "args": [
-                "-OutputDirectory", "${workspaceFolder}\\Output\\Configuration"
+                "-OutputDirectory", "${workspaceFolder}"
             ],
             "presentation": {
                 "echo": true,
@@ -29,7 +29,7 @@
             "type": "shell",
             "command": "Invoke-ScriptAnalyzer",
             "args": [
-                "-Path", "${workspaceFolder}\\Output\\"
+                "-Path", "(Get-Module Configuration -List | Sort Version -Desc | Select -First 1 -Expand ModuleBase)"
             ],
             "presentation": {
                 "echo": true,
@@ -49,15 +49,13 @@
             "type": "shell",
             "options": {
                 "cwd": "${workspaceFolder}",
-                "env": {
-                    "PSModulePath": "${workspaceFolder}\\Output;${env:PSModulePath}"
-                }
+
             },
             "command": "Invoke-Gherkin",
             "args": [
                 "-Path", "${workspaceFolder}\\Specs",
                 "-PesterOption", "@{ IncludeVSCodeMarker = $True }",
-                "-CodeCoverage", "${workspaceFolder}\\Output\\*.psm1"
+                "-CodeCoverage", "(Convert-Path (Join-Path (Split-Path (Get-Module Configuration -List | Sort Version -Desc | Select -First 1 -Expand ModuleBase)) *.psm1))"
             ],
             "presentation": {
                 "echo": true,

--- a/Build.ps1
+++ b/Build.ps1
@@ -6,12 +6,9 @@ param(
 
     # The version of the output module
     [Alias("ModuleVersion")]
-    [string]$SemVer,
-
-    # Optionally, a local folder that modules and CLI tools can be installed in
-    $LocalTools = "./RequiredModules"
+    [string]$SemVer
 )
-Push-Location $PSScriptRoot -StackName BuildWindowsConsoleFont
+Push-Location $PSScriptRoot -StackName BuildTestStack
 
 if (!$SemVer -and (Get-Command gitversion -ErrorAction Ignore)) {
     $PSBoundParameters['SemVer'] = gitversion -showvariable nugetversion
@@ -40,5 +37,5 @@ try {
     # Remove the extra metadata file
     Remove-Item $MetadataInfo.Path
 } finally {
-    Pop-Location -StackName BuildWindowsConsoleFont
+    Pop-Location -StackName BuildTestStack
 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,32 @@
-# Configuration
+[![Build Status](https://dev.azure.com/poshcode/Configuration/_apis/build/status/Configuration?branchName=master)](https://dev.azure.com/poshcode/Configuration/_build/latest?definitionId=2&branchName=master)
 
-A module for saving and loading settings and configuration objects for PowerShell modules (and scripts).
+# The Configuration Module
 
-The Configuration module supports layered configurations with default values, and serializes objects and hashtables to the simple PowerShell metadata format with the ability to extend how your custom types are serialized, so your configuration files are just .psd1 files!
+## Metadata commands for working with .psd1:
 
-The key feature is that you don't have to worry about where to store files, and modules using the Configuration commands will be able to easily store data even when installed in write-protected folders like Program Files.
+- Manipulating metadata files
+- Extensible serialization of types
+- Built in support for DateTime, Version, Guid, SecureString, ScriptBlocks and more
+- Lets you store almost anything in readable metadata (.psd1) files
+- Serializing (`Export`) to metadata (.psd1) files
+- Deserializing (`Import`) from metadata (.psd1) files
 
-Supports WindowsPowerShell, as well as PowerShell Core on Windows, Linux and OS X.
+## Configuration commands for loading settings:
+
+- Ship default configuration files with your module
+- Automatically determines where to save your settings
+    - Supports Windows roaming profiles
+    - Supports XDG settings for Linux (and MacOS)
+- Allow users to configure settings using our commands, or your wrappers
+- Supports _layered_ configurations:
+  - Machine-level config
+  - User override files
+- Supports automatic configuration of parameters values for a command
+  - Reads `Noun` configuration files in your working directory
+  - Filters only values which apply to the current command
+
+
+It supports WindowsPowerShell, as well as PowerShell Core on Windows, Linux and OS X.
 
 ## Installation
 

--- a/Source/Configuration/Public/Import-ParameterConfiguration.ps1
+++ b/Source/Configuration/Public/Import-ParameterConfiguration.ps1
@@ -1,0 +1,127 @@
+function Import-ParameterConfiguration {
+    <#
+        .SYNOPSIS
+            Loads a metadata file based on the calling command name and combines the values there with the parameter values of the calling function.
+        .DESCRIPTION
+            This function gives command authors and users an easy way to let the default parameter values of the command be set by a configuration file in the folder you call it from.
+
+            Normally, you have three places to get parameter values from. In priority order, they are:
+            - Parameters passed by the caller always win
+            - The PowerShell $PSDefaultParameterValues hashtable appears to the function as if the user passed it
+            - Default parameter values (defined in the function)
+
+            If you call this command at the top of a function, it overrides (only) the default parameter values with
+
+            - Values from a manifest file in the present working directory ($pwd)
+        .Example
+            Given that you've written a script like:
+
+            function New-User {
+                [CmdletBinding()]
+                param(
+                    $FirstName,
+                    $LastName,
+                    $UserName,
+                    $Domain,
+                    $EMail
+                )
+                Import-ParameterConfiguration
+                # Possibly calculated based on (default) parameter values
+                if (-not $UserName) { $UserName = "$FirstName.$LastName" }
+                if (-not $EMail)    { $EMail = "$UserName@$Domain" }
+
+                # Lots of work to create the user's AD account and email etc.
+                [PSCustomObject]@{
+                    PSTypeName = "MagicUser"
+                    FirstName = $FirstName
+                    LastName = $LastName
+                    EMail      = $EMail
+                }
+            }
+
+            You could create a User.psd1 in a folder with just:
+
+            @{ Domain = "HuddledMasses.org" }
+
+            Now the following command would resolve the `User.psd1`
+            And the user would get an appropriate email address automatically:
+
+            PS> New-User Joel Bennett
+
+        .Example
+            Following up on our earlier example, imagine that you wanted different configuration files for each department ...
+
+            You could create department specific files in your folder, like Security-User.psd1 with something like
+
+            @{
+                Domain = "HuddledMasses.org"
+                Permissions = @{
+                    # whatever you need
+                }
+            }
+
+            And then modify your function like ...
+
+            function New-User {
+                [CmdletBinding()]
+                param(
+                    $FirstName,
+                    $LastName,
+                    $UserName,
+                    $Domain,
+                    $EMail,
+                    $Department,
+                    [hashtable]$Permissions
+                )
+                Import-ParameterConfiguration -FileName "${Department}User.psd1"
+                # Possibly calculated based on (default) parameter values
+                if (-not $UserName) { $UserName = "$FirstName.$LastName" }
+                if (-not $EMail)    { $EMail = "$UserName@$Domain" }
+
+                # Lots of work to create the user's AD account and email etc.
+                [PSCustomObject]@{
+                    PSTypeName = "MagicUser"
+                    FirstName = $FirstName
+                    LastName = $LastName
+                    EMail      = $EMail
+                    # Passthru for testing
+                    Permissions = $Permissions
+                }
+            }
+
+            Now the following command would resolve the `SecurityUser.psd1`
+            And the user would get appropriate permissions automatically:
+
+            PS> New-User Joel Bennett -Department Security
+    #>
+    [CmdletBinding()]
+    param(
+        # The folder the configuration should be read from. Defaults to the current working directory
+        [string]$WorkingDirectory = $pwd,
+        # The name of the configuration file.
+        # The default value is your command's Noun, with the ".psd1" extention.
+        # So if you call this from a command named Build-Module, the noun is "Module" and the config $FileName is "Module.psd1"
+        [string]$FileName
+    )
+
+    $CallersInvocation = @(Get-PSCallStack)[1].InvocationInfo
+    if (-not $PSBoundParameters.ContainsKey("FileName")) {
+        $FileName = "$($CallersInvocation.MyCommand.Noun).psd1"
+    }
+
+    $FileName = Join-Path $WorkingDirectory $FileName
+
+    if (Test-Path $FileName) {
+        Write-Debug "Initializing parameters for $($CallersInvocation.InvocationName) from $(Join-Path $WorkingDirectory $CallersInvocation.MyCommand.Noun).psd1"
+        $ConfiguredDefaults = Import-Metadata $FileName -ErrorAction SilentlyContinue
+
+        foreach ($Parameter in $CallersInvocation.MyCommand.Parameters.Keys) {
+            # If it's in the defaults AND it was not passed in as a parameter ...
+            if ($ConfiguredDefaults.ContainsKey($Parameter) -and -not ($CallersInvocation.BoundParameters -and $CallersInvocation.BoundParameters.ContainsKey($Parameter))) {
+                Write-Debug "Export $Parameter = $($ConfiguredDefaults[$Parameter])"
+                # This "SessionState" is the _callers_ SessionState, not ours
+                $PSCmdlet.SessionState.PSVariable.Set($Parameter, $ConfiguredDefaults[$Parameter])
+            }
+        }
+    }
+}

--- a/Source/Configuration/Public/Import-ParameterConfiguration.ps1
+++ b/Source/Configuration/Public/Import-ParameterConfiguration.ps1
@@ -159,7 +159,7 @@ function Import-ParameterConfiguration {
         [switch]$Recurse
     )
 
-    $CallersInvocation = @(Get-PSCallStack)[1].InvocationInfo
+    $CallersInvocation = $PSCmdlet.SessionState.PSVariable.GetValue("MyInvocation")
     $BoundParameters = @{} + $CallersInvocation.BoundParameters
     $AllParameters = $CallersInvocation.MyCommand.Parameters.Keys
     if (-not $PSBoundParameters.ContainsKey("FileName")) {

--- a/Source/Metadata/Metadata.psd1
+++ b/Source/Metadata/Metadata.psd1
@@ -23,6 +23,7 @@ Description = 'A module for PowerShell data serialization'
 
 # This doesn't make it into the build output, so it's irrelevant
 FunctionsToExport = '*-*'
+AliasesToExport = '*'
 PrivateData   = @{ PSData = @{ Prerelease = "" } }
 
 }

--- a/Specs/Configuration.Steps.ps1
+++ b/Specs/Configuration.Steps.ps1
@@ -250,13 +250,13 @@ Given "a (?:settings file|module manifest) named (\S+)(?:(?: in the (?<Scope>\S+
 
     if ($Scope -in "current","parent") {
         $folder = "TestDrive:/Level1/Level2/"
-    } elseif($Scope -and $Version) {
+    } elseif ($Scope -and $Version) {
         $folder = GetStoragePath -Scope $Scope -Version $Version
-    } elseif($Scope) {
+    } elseif ($Scope) {
         $folder = GetStoragePath -Scope $Scope
-    } elseif($Version) {
+    } elseif ($Version) {
         $folder = GetStoragePath -Version $Version
-    } elseif(Test-Path "$ModulePath") {
+    } elseif ($ModulePath -and (Test-Path "$ModulePath")) {
         $folder = $ModulePath
     } else {
         $folder = "TestDrive:/"

--- a/Specs/Configuration.feature
+++ b/Specs/Configuration.feature
@@ -20,8 +20,8 @@ Feature: Module Configuration
             """
         When I call Import-Configuration
         Then the settings object should be of type hashtable
-        And the settings object should have a UserName of type String
-        And the settings object should have an Age of type Int32
+        And the settings object's UserName should be of type String
+        And the settings object's Age should be of type Int32
 
 
     @Modules @EndUsers
@@ -36,8 +36,8 @@ Feature: Module Configuration
             """
         When the ModuleInfo is piped to Import-Configuration
         Then the settings object should be of type hashtable
-        And the settings object should have a UserName of type String
-        And the settings object should have an Age of type Int32
+        And the settings object's UserName should be of type String
+        And the settings object's Age should be of type Int32
 
     @Modules @Import @EndUsers
     Scenario: End users should be able to work with configuration data outside the module
@@ -51,8 +51,8 @@ Feature: Module Configuration
             """
         When the ModuleInfo is piped to Import-Configuration
         Then the settings object should be of type hashtable
-        And the settings object should have a UserName of type String
-        And the settings object should have an Age of type Int32
+        And the settings object's UserName should be of type String
+        And the settings object's Age should be of type Int32
 
     @Modules @Import
     Scenario: SxS Versions
@@ -164,3 +164,5 @@ Feature: Module Configuration
     #     Then the settings from the old version should be copied
     #     And MyModule should be able to migrate them
     #     But they should save only to the new version
+
+

--- a/Specs/DefaultParameters.feature
+++ b/Specs/DefaultParameters.feature
@@ -3,11 +3,14 @@ Feature: Configure Command From Working Directory
     There is a command to support loading default parameter values from the working directory
 
     Background:
-        Given a passthru command 'Test-Verb' with UserName and Age parameters
+        Given the configuration module is imported with testing paths:
+            | Enterprise                | User                | Machine                |
+            | TestDrive:/EnterprisePath | TestDrive:/UserPath | TestDrive:/MachinePath |
 
     @Functions @Import
     Scenario: Loading Default Settings
-        Given a local file named Verb.psd1
+        Given a passthru command 'Test-Verb' with UserName and Age parameters
+        And a settings file named Verb.psd1 in the current folder
             """
             @{
             UserName = 'Joel'
@@ -20,7 +23,8 @@ Feature: Configure Command From Working Directory
 
     @Functions @Import
     Scenario: Overriding Default Settings
-        Given a local file named Verb.psd1
+        Given a passthru command 'Test-Verb' with UserName and Age parameters
+        And a settings file named Verb.psd1 in the current folder
             """
             @{
             UserName = 'Joel'
@@ -31,14 +35,24 @@ Feature: Configure Command From Working Directory
         Then the output object's userName should be Mark
         And the output object's Age should be 42
 
+    @Functions @Import
+    Scenario: Overriding Default Settings Works on any Parameter
+        Given a passthru command 'Test-Verb' with UserName and Age parameters
+        And a settings file named Verb.psd1 in the current folder
+            """
+            @{
+            UserName = 'Joel'
+            Age = 42
+            }
+            """
         When I call Test-Verb -Age 10
         Then the output object's userName should be Joel
         And the output object's Age should be 10
 
     @Functions @Import
-    Scenario: Parameter Values
+    Scenario: New-User Example
         Given an example New-User command
-        And a local file named User.psd1
+        And a settings file named User.psd1 in the current folder
             """
             @{
                 Domain = 'HuddledMasses.org'
@@ -48,9 +62,9 @@ Feature: Configure Command From Working Directory
         Then the output object's EMail should be Joel.Bennett@HuddledMasses.org
 
     @Functions @Import
-    Scenario: Parameter Values
+    Scenario: New-User Example Two
         Given an example New-User command
-        And a local file named SecurityUser.psd1
+        And a settings file named SecurityUser.psd1 in the current folder
             """
             @{
                 Domain = 'HuddledMasses.org'

--- a/Specs/DefaultParameters.feature
+++ b/Specs/DefaultParameters.feature
@@ -62,19 +62,52 @@ Feature: Configure Command From Working Directory
         Then the output object's EMail should be Joel.Bennett@HuddledMasses.org
 
     @Functions @Import
-    Scenario: New-User Example Two
+    Scenario: New-User Example Two (overwriting)
+        Given an example New-User command
+        And a settings file named User.psd1 in the current folder
+            """
+            @{
+                Permissions = @{
+                    Access = "Administrator"
+                }
+            }
+            """
+        And a settings file named User.psd1 in the parent folder
+            """
+            @{
+                Department = "Security"
+                Permissions = @{
+                    Access = "User"
+                }
+            }
+            """
+        And a settings file named User.psd1
+            """
+            @{
+                Domain = "HuddledMasses.org"
+            }
+            """
+        When I call New-User Joel Bennett
+        Then the output object's EMail should be Joel.Bennett@HuddledMasses.org
+        And the output object's Department should be Security
+        And the output object's Permissions should be of type [hashtable]
+        And the output object's Permissions.Access should be Admininstrator
+
+
+    @Functions @Import
+    Scenario: New-User Example Three
         Given an example New-User command
         And a settings file named SecurityUser.psd1 in the current folder
             """
             @{
                 Domain = 'HuddledMasses.org'
                 Permissions = @{
-                    Azure = "Admin1"
+                    Access = "Administrator"
                 }
             }
             """
         When I call New-User Joel Bennett -Department Security
         Then the output object's EMail should be Joel.Bennett@HuddledMasses.org
         And the output object's Permissions should be of type [hashtable]
-        And the output object's Permissions.Azure should be of type [string]
-        And the output object's Permissions.Azure should be Admin1
+        And the output object's Permissions.Access should be of type [string]
+        And the output object's Permissions.Access should be Admininstrator

--- a/Specs/DefaultParameters.feature
+++ b/Specs/DefaultParameters.feature
@@ -91,7 +91,7 @@ Feature: Configure Command From Working Directory
         Then the output object's EMail should be Joel.Bennett@HuddledMasses.org
         And the output object's Department should be Security
         And the output object's Permissions should be of type [hashtable]
-        And the output object's Permissions.Access should be Admininstrator
+        And the output object's Permissions.Access should be Administrator
 
 
     @Functions @Import
@@ -110,4 +110,4 @@ Feature: Configure Command From Working Directory
         Then the output object's EMail should be Joel.Bennett@HuddledMasses.org
         And the output object's Permissions should be of type [hashtable]
         And the output object's Permissions.Access should be of type [string]
-        And the output object's Permissions.Access should be Admininstrator
+        And the output object's Permissions.Access should be Administrator

--- a/Specs/DefaultParameters.feature
+++ b/Specs/DefaultParameters.feature
@@ -1,0 +1,66 @@
+Feature: Configure Command From Working Directory
+
+    There is a command to support loading default parameter values from the working directory
+
+    Background:
+        Given a passthru command 'Test-Verb' with UserName and Age parameters
+
+    @Functions @Import
+    Scenario: Loading Default Settings
+        Given a local file named Verb.psd1
+            """
+            @{
+            UserName = 'Joel'
+            Age = 42
+            }
+            """
+        When I call Test-Verb
+        Then the output object's userName should be Joel
+        And the output object's Age should be 42
+
+    @Functions @Import
+    Scenario: Overriding Default Settings
+        Given a local file named Verb.psd1
+            """
+            @{
+            UserName = 'Joel'
+            Age = 42
+            }
+            """
+        When I call Test-Verb Mark
+        Then the output object's userName should be Mark
+        And the output object's Age should be 42
+
+        When I call Test-Verb -Age 10
+        Then the output object's userName should be Joel
+        And the output object's Age should be 10
+
+    @Functions @Import
+    Scenario: Parameter Values
+        Given an example New-User command
+        And a local file named User.psd1
+            """
+            @{
+                Domain = 'HuddledMasses.org'
+            }
+            """
+        When I call New-User Joel Bennett
+        Then the output object's EMail should be Joel.Bennett@HuddledMasses.org
+
+    @Functions @Import
+    Scenario: Parameter Values
+        Given an example New-User command
+        And a local file named SecurityUser.psd1
+            """
+            @{
+                Domain = 'HuddledMasses.org'
+                Permissions = @{
+                    Azure = "Admin1"
+                }
+            }
+            """
+        When I call New-User Joel Bennett -Department Security
+        Then the output object's EMail should be Joel.Bennett@HuddledMasses.org
+        And the output object's Permissions should be of type [hashtable]
+        And the output object's Permissions.Azure should be of type [string]
+        And the output object's Permissions.Azure should be Admin1

--- a/Specs/LocalStoragePathLinux.feature
+++ b/Specs/LocalStoragePathLinux.feature
@@ -14,7 +14,7 @@ Feature: Automatically Calculate Local Storage Paths on Linux
         Given the configuration module is imported on Linux:
         Given a module with the name '<modulename>' with the author 'Jaykul'
         Then the module's <scope> path should match '^<rootpattern>' and '/Jaykul/<modulename>$'
-        And the module's <scope> path should exist already
+        # And the module's <scope> path should exist already
 
         Examples:
             | scope      | modulename      | rootpattern    |

--- a/Specs/Serialization.feature
+++ b/Specs/Serialization.feature
@@ -148,15 +148,15 @@ Feature: Serialize Hashtables or Custom Objects
               Homepage = [Uri]"http://HuddledMasses.org"
             }
             """
-        Then the settings object should have a Homepage of type Uri
+        Then the settings object's Homepage should be of type Uri
         And we add a converter for Uri types
         And we convert the settings to metadata
         When we convert the metadata to an object
         Then the settings object should be of type hashtable
-        Then the settings object should have a UserName of type String
-        Then the settings object should have an Age of type Int32
-        Then the settings object should have a LastUpdated of type DateTime
-        Then the settings object should have a Homepage of type Uri
+        Then the settings object's UserName should be of type String
+        Then the settings object's Age should be of type Int32
+        Then the settings object's LastUpdated should be of type DateTime
+        Then the settings object's Homepage should be of type Uri
 
     @DeSerialization @SecureString @PSCredential @CRYPT32
     Scenario Outline: I should be able to import serialized credentials and secure strings
@@ -172,8 +172,8 @@ Feature: Serialize Hashtables or Custom Objects
         And the string version should match "Password = \(?ConvertTo-SecureString [\"a-z0-9]*"
         When we convert the metadata to an object
         Then the settings object should be of type hashtable
-        Then the settings object should have a Credential of type PSCredential
-        Then the settings object should have a Password of type SecureString
+        Then the settings object's Credential should be of type PSCredential
+        Then the settings object's Password should be of type SecureString
 
     @Serialization @SecureString @CRYPT32
     Scenario Outline: Should be able to serialize SecureStrings
@@ -198,11 +198,11 @@ Feature: Serialize Hashtables or Custom Objects
         And we convert the settings to metadata
         When we convert the metadata to an object
         Then the settings object should be of type hashtable
-        And the settings object should have a UserName of type PSObject
-        And the settings object should have an Age of type String
-        And the settings object should have a LastUpdated of type DateTimeOffset
-        And the settings object should have a GUID of type GUID
-        And the settings object should have a Color of type ConsoleColor
+        And the settings object's UserName should be of type PSObject
+        And the settings object's Age should be of type String
+        And the settings object's LastUpdated should be of type DateTimeOffset
+        And the settings object's GUID should be of type GUID
+        And the settings object's Color should be of type ConsoleColor
 
     @Deserialization @Uri @Converter
     Scenario: I should be able to add converters at import time
@@ -215,7 +215,7 @@ Feature: Serialize Hashtables or Custom Objects
               Homepage = [Uri]"http://HuddledMasses.org"
             }
             """
-        Then the settings object should have a Homepage of type Uri
+        Then the settings object's Homepage should be of type Uri
         And we convert the settings to metadata
         Then the string version should match
             """
@@ -223,9 +223,9 @@ Feature: Serialize Hashtables or Custom Objects
             """
         When we convert the metadata to an object
         Then the settings object should be of type hashtable
-        And the settings object should have a UserName of type String
-        And the settings object should have an Age of type Int32
-        And the settings object should have a Homepage of type Uri
+        And the settings object's UserName should be of type String
+        And the settings object's Age should be of type Int32
+        And the settings object's Homepage should be of type Uri
 
 
     @Deserialization @File
@@ -241,8 +241,8 @@ Feature: Serialize Hashtables or Custom Objects
         And we fake version 2.0 in the Metadata module
         When we import the file to an object
         Then the settings object should be of type hashtable
-        And the settings object should have a UserName of type String
-        And the settings object should have an Age of type Int32
+        And the settings object's UserName should be of type String
+        And the settings object's Age should be of type Int32
 
 
     @Deserialization @File
@@ -257,8 +257,8 @@ Feature: Serialize Hashtables or Custom Objects
             """
         When we import the file to an object
         Then the settings object should be of type hashtable
-        Then the settings object should have a UserName of type String
-        Then the settings object should have an Age of type Int32
+        Then the settings object's UserName should be of type String
+        Then the settings object's Age should be of type Int32
 
     @Deserialization @File
     Scenario: Imported metadata files should be able to use PSScriptRoot
@@ -272,7 +272,7 @@ Feature: Serialize Hashtables or Custom Objects
         And we're using PowerShell 4 or higher in the Metadata module
         When we import the file to an object
         Then the settings object should be of type hashtable
-        And the settings object should have a MyPath of type String
+        And the settings object's MyPath should be of type String
         And the settings object MyPath should match the file's path
 
 
@@ -314,8 +314,8 @@ Feature: Serialize Hashtables or Custom Objects
             """
         When we import the folder path
         Then the settings object should be of type hashtable
-        Then the settings object should have a UserName of type String
-        Then the settings object should have an Age of type Int32
+        Then the settings object's UserName should be of type String
+        Then the settings object's Age should be of type Int32
 
     @Serialization @Deserialization @File
     Scenario: Errors when you import missing files
@@ -419,8 +419,8 @@ Feature: Serialize Hashtables or Custom Objects
             """
         When we import the file with ordered
         Then the settings object should be of type Collections.Specialized.OrderedDictionary
-        And the settings object should have a UserName of type String
-        And the settings object should have an Age of type Int32
+        And the settings object's UserName should be of type String
+        And the settings object's Age should be of type Int32
         And Key 0 is UserName
         And Key 1 is Age
         And Key 2 is FullName
@@ -441,7 +441,7 @@ Feature: Serialize Hashtables or Custom Objects
             """
         When we import the file with ordered
         Then the settings object should be of type Collections.Specialized.OrderedDictionary
-        And the settings object should have a FullName of type Collections.Specialized.OrderedDictionary
+        And the settings object's FullName should be of type Collections.Specialized.OrderedDictionary
 
     @Regression @Serialization
     Scenario: Arrays of custom types

--- a/Test.ps1
+++ b/Test.ps1
@@ -4,23 +4,20 @@
 #>
 [CmdletBinding()]
 param(
-    # A specific folder to build into
-    $OutputDirectory,
+    # A specific folder the build is in
+    $OutputDirectory = $PSScriptRoot,
 
     # The version of the output module
     [Alias("ModuleVersion")]
-    [string]$SemVer,
-
-    # Optionally, a local folder that modules and CLI tools can be installed in
-    $LocalTools = "./RequiredModules"
+    [string]$SemVer
 )
-Push-Location $PSScriptRoot -StackName BuildWindowsConsoleFont
+Push-Location $PSScriptRoot -StackName BuildTestStack
 
-# The init script sets default values for the parameters and fixes paths
-. $PSScriptRoot/Init.ps1
+if (!$SemVer -and (Get-Command gitversion -ErrorAction Ignore)) {
+    $SemVer = gitversion -showvariable nugetversion
+}
 
 Write-Host "OutputDirectory: $OutputDirectory"
-Write-Host "LocalTools: $LocalTools"
 Write-Host "SemVer: $SemVer"
 
 try {
@@ -42,7 +39,6 @@ try {
     Invoke-Command {
         # We need to make sure that the PSModulePath has our output at the front
         $Env:PSModulePath = $OutputDirectory + [IO.Path]::PathSeparator +
-                            $LocalTools + [IO.Path]::PathSeparator +
                             $Env:PSModulePath
 
         Write-Host "Testing Configuration $SemVer"
@@ -55,5 +51,5 @@ try {
     }
 
 } finally {
-    Pop-Location -StackName BuildWindowsConsoleFont
+    Pop-Location -StackName BuildTestStack
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,13 +12,13 @@ resources:
       type: github
       endpoint: github # You'll need to define a service connection in your project on Azure
       name: PoshCode/Azure-Pipelines
-      ref: refs/tags/3.0.1
+      ref: refs/tags/3.2.0
 
-jobs:
+stages:
+- stage: Build
+  jobs:
   - template: GitVersion-job.yml@poshcode
-
-  # using a custom build job because we have two modules
-  - job: Build
+  - job: Build # using a custom build job because we have two modules
     pool:
       vmImage: windows-2019
     dependsOn: GitVersion
@@ -35,16 +35,30 @@ jobs:
       displayName: Publish Build Output
       inputs:
         artifactName: $(ArtifactName)
-        targetPath: $(Build.BinariesDirectory)/$(Build.DefinitionName)
+        targetPath: $(Build.BinariesDirectory)
 
+- stage: Test
+  dependsOn: Build
+  jobs:
   - template: ScriptAnalyzer-job.yml@poshcode
     parameters:
-      dependsOn: ['Build']
+      dependsOn: []
       artifactName: $(ArtifactName)
       excludeRules: ["PSShouldProcess","PSUseShouldProcessForStateChangingFunctions","PSAvoidUsingDeprecatedManifestFields","PSPossibleIncorrectUsageOfAssignmentOperator"]
 
   - template: Gherkin-job.yml@poshcode
     parameters:
-      dependsOn: ['Build']
+      dependsOn: []
       artifactName: $(ArtifactName)
       specDirectory: '$(Build.SourcesDirectory)/Specs'
+      strategy:
+        matrix:
+          Linux:
+            vmImage: 'ubuntu-16.04'
+          MacOS:
+            vmImage: 'macOS-10.14'
+          Windows:
+            vmImage: 'windows-2019'
+      pool:
+        vmImage: $(vmImage)
+


### PR DESCRIPTION
First version of this function:

It imports a `Noun.psd1` file when called from a `Verb-Noun` command, and sets variables for the parameters which are configured in the settings file but weren't passed on the command-line, basically allowing you to create commands which read configuration files from the current working directory.

The question is: should it recurse up the parent directories looking for `noun.psd1` files that might define values that aren't already defined?